### PR TITLE
Small fixes 1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ resolvers ++= Seq(
 )
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
-val defaultVersions = Map("firrtl" -> "1.1-SNAPSHOT")
+val defaultVersions = Map("firrtl" -> "1.2-SNAPSHOT")
 
 libraryDependencies ++= (Seq("firrtl").map {
   dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) })

--- a/src/main/scala/treadle/Driver.scala
+++ b/src/main/scala/treadle/Driver.scala
@@ -19,7 +19,6 @@ case class TreadleOptions(
     lowCompileAtLoad   : Boolean              = true,
     validIfIsRandom    : Boolean              = false,
     rollbackBuffers    : Int                  = 4,
-    clockName          : String               = "clock",
     clockInfo          : Seq[ClockInfo]       = Seq.empty,
     resetName          : String               = "reset",
     noDefaultReset     : Boolean              = false,
@@ -122,14 +121,6 @@ trait HasInterpreterOptions {
       treadleOptions = treadleOptions.copy(rollbackBuffers = x)
     }
     .text("number of rollback buffers, 0 is no buffers, default is 4")
-
-  parser.opt[String]("fint-clock-name")
-    .abbr("ficn")
-    .valueName("<string>")
-    .foreach { x =>
-      treadleOptions = treadleOptions.copy(clockName = x)
-    }
-    .text("name of default clock")
 
   def parseClockInfo(input: String): ClockInfo = {
     input.split(":").map(_.trim).toList match {

--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -38,7 +38,6 @@ class TreadleTester(input: String, optionsManager: HasInterpreterSuite = new Int
     )
   }
 
-  val clockName: String = treadleOptions.clockName
   val resetName: String = treadleOptions.resetName
 
   val combinationalDelay: Long = 10

--- a/src/main/scala/treadle/executable/DataStore.scala
+++ b/src/main/scala/treadle/executable/DataStore.scala
@@ -27,6 +27,9 @@ class DataStore(val numberOfBuffers: Int, optimizationLevel: Int = 0) {
   nextIndexFor(LongSize) = 0
   nextIndexFor(BigSize)  = 0
 
+  val plugIns       : mutable.HashMap[String, DataStorePlugIn] = new mutable.HashMap()
+  val activePlugins : mutable.ArrayBuffer[DataStorePlugIn]     = new mutable.ArrayBuffer()
+
   private var executionEngineOption: Option[ExecutionEngine] = None
   def setExecutionEngine(executionEngine: ExecutionEngine): Unit = {
     executionEngineOption = Some(executionEngine)

--- a/src/main/scala/treadle/executable/DataStorePlugIn.scala
+++ b/src/main/scala/treadle/executable/DataStorePlugIn.scala
@@ -1,0 +1,9 @@
+// See LICENSE for license details.
+
+package treadle.executable
+
+abstract class DataStorePlugIn {
+  def setEnabled(enabled: Boolean): Unit
+  def isEnabled: Boolean
+  def run(symbol: Symbol): Unit
+}

--- a/src/main/scala/treadle/executable/SymbolTable.scala
+++ b/src/main/scala/treadle/executable/SymbolTable.scala
@@ -136,8 +136,12 @@ class SymbolTable(nameToSymbol: mutable.HashMap[String, Symbol]) {
 object SymbolTable extends LazyLogging {
 
   val RegisterInputSuffix = "/in"
+  val LastValueSuffix     = "/last"
+
   def makeRegisterInputName(name: String): String = name + RegisterInputSuffix
   def makeRegisterInputName(symbol: Symbol): String = symbol.name + RegisterInputSuffix
+  def makeLastValueName(name: String)       : String = name + LastValueSuffix
+  def makeLastValueName(symbol: Symbol)     : String = symbol.name + LastValueSuffix
 
   def apply(nameToSymbol: mutable.HashMap[String, Symbol]): SymbolTable = new SymbolTable(nameToSymbol)
 

--- a/src/test/scala/treadle/blackboxes/BlackBoxOutputSpec.scala
+++ b/src/test/scala/treadle/blackboxes/BlackBoxOutputSpec.scala
@@ -170,27 +170,5 @@ class BlackBoxOutputSpec extends FreeSpec with Matchers {
         tester.step()
       }
     }
-
-    "each output should hold a different values" in {
-
-      val factory = new BlackBoxCounterFactory
-
-      val optionsManager = new InterpreterOptionsManager {
-        treadleOptions = treadleOptions.copy(
-          setVerbose = false,
-          blackBoxFactories = Seq(factory),
-          randomSeed = 0L)
-      }
-      val tester = new TreadleTester(input, optionsManager)
-
-      tester.poke("clear", 1)
-      tester.step()
-      tester.poke("clear", 0)
-
-      for(i <- 0 until 10) {
-        tester.expect("counter", i)
-        tester.step()
-      }
-    }
   }
 }

--- a/treadle.sh
+++ b/treadle.sh
@@ -1,1 +1,2 @@
-sbt -mem 4000 "run-main treadle.TreadleRepl $*"
+#!/usr/bin/env bash
+sbt -mem 4000 "runMain treadle.TreadleRepl $*"


### PR DESCRIPTION
Add new repl command symbol which can show symbol table entries  …
Fix treadle launch script
Removed unused option clockname
bump build.sbt dependency versions
Do some ground work for moving register latch info into datastore
Do some ground work for making datastore plugins for debugging
Duplicate test removed.