### PR TITLE
This fixes a memory reader naming problem

### DIFF
--- a/src/main/scala/treadle/executable/Memory.scala
+++ b/src/main/scala/treadle/executable/Memory.scala
@@ -85,7 +85,7 @@ object Memory {
       sensitivityGraphBuilder.addSensitivity(clk, data)
 
       val pipelineDataSymbols = (0 until memory.readLatency).flatMap { n =>
-        buildRegisterTriple(s"$expandedName.$readerString.pipeline_", n, dataType)
+        buildRegisterTriple(s"$expandedName.$readerString.pipeline_data_", n, dataType)
       }
 
       buildPipelineDependencies(addr, pipelineDataSymbols, Some(data))


### PR DESCRIPTION
Register implemented for read latency > 0
had inconsistent names, between parsing and compilation.