### PR TITLE
Render assigners prettier using ExpressionViewRenderer

### DIFF
--- a/src/main/scala/treadle/ExecutionEngine.scala
+++ b/src/main/scala/treadle/ExecutionEngine.scala
@@ -25,6 +25,12 @@ class ExecutionEngine(
   var vcdOption: Option[VCD] = None
   var vcdFileName: String = ""
 
+  val expressionViewRenderer = new ExpressionViewRenderer(
+    dataStore,
+    symbolTable,
+    expressionViews
+  )
+
   var verbose: Boolean = false
   setVerbose(interpreterOptions.setVerbose)
 
@@ -449,13 +455,14 @@ object ExecutionEngine {
       loweredAst, blackBoxFactories)
 
     scheduler.organizeAssigners()
-    if(verbose) {
-      println(s"\n${scheduler.render}")
-      scheduler.setVerboseAssign(verbose)
-    }
 
     val executionEngine = new ExecutionEngine(ast, optionsManager, symbolTable, dataStore, scheduler, expressionViews)
     executionEngine.dataStore.setExecutionEngine(executionEngine)
+
+    if(verbose) {
+      println(s"\n${scheduler.render(executionEngine)}")
+      scheduler.setVerboseAssign(verbose)
+    }
 
     executionEngine.inputsChanged = true
 

--- a/src/main/scala/treadle/executable/ExpressionViewBuilder.scala
+++ b/src/main/scala/treadle/executable/ExpressionViewBuilder.scala
@@ -8,7 +8,6 @@ import firrtl.ir._
 import treadle._
 import RenderHelper.ExpressionHelper
 
-
 import scala.collection.mutable
 
 //noinspection ScalaUnusedSymbol
@@ -209,7 +208,7 @@ class ExpressionViewBuilder(
             val processedExpression = processExpression(con.expr)
 
             expressionViews(registerIn) = processedExpression
-            expressionViews(registerOut) = expression"$registerOut"
+            expressionViews(registerOut) = expression"$registerIn"
           }
 
         case WDefInstance(info, instanceName, moduleName, _) =>
@@ -251,11 +250,17 @@ class ExpressionViewBuilder(
         case DefWire(info, name, tpe) =>
 
         case DefRegister(info, name, tpe, clockExpression, resetExpression, initValueExpression) =>
+          val registerName = expand(name)
+          val registerInputName = SymbolTable.makeRegisterInputName(registerName)
+          val registerInput = symbolTable(registerInputName)
+
+          expressionViews(symbolTable(registerName)) = expression"$registerInput"
 
         case defMemory: DefMemory =>
           val expandedName = expand(defMemory.name)
           logger.debug(s"declaration:DefMemory:${defMemory.name} becomes $expandedName")
 
+          Memory.buildMemoryExpressions(defMemory, expandedName, scheduler, expressionViews)
         case IsInvalid(info, expression) =>
 
         case stop @ Stop(info, ret, clockExpression, enableExpression) =>

--- a/src/test/scala/treadle/RiscVMiniSimpleSpec.scala
+++ b/src/test/scala/treadle/RiscVMiniSimpleSpec.scala
@@ -5,6 +5,7 @@ package treadle
 import org.scalatest.{FreeSpec, Matchers}
 import treadle.executable.ClockInfo
 
+//scalastyle:off magic.number
 class RiscVMiniSimpleSpec extends FreeSpec with Matchers {
   "riscv-mini simple core test should run then stop" in {
 


### PR DESCRIPTION
* Add register <= register/in
* Add memory handler to generate expression renders
  * Add new Memory method buildMemoryExpressions
  * creation is emulation of assigner creation pass
* Add new parameters to rendering to not show values
* Fixed some related scheduler problems
  * orphans were not computed before attempting to run static stuff
  * orphans were not being removed from combinational assigns
  * renderer was improved to use new expression view stuff