### PR TITLE
TreadleTester should not run reset by default, it might confuse

### DIFF
--- a/src/main/scala/treadle/Driver.scala
+++ b/src/main/scala/treadle/Driver.scala
@@ -12,17 +12,17 @@ case class TreadleOptions(
     setVerbose         : Boolean              = false,
     setOrderedExec     : Boolean              = false,
     allowCycles        : Boolean              = false,
-    randomSeed         : Long                 = System.currentTimeMillis(),
-    blackBoxFactories  : Seq[BlackBoxFactory] = Seq.empty,
-    maxExecutionDepth  : Long                 = Int.MaxValue,
-    showFirrtlAtLoad   : Boolean              = false,
-    lowCompileAtLoad   : Boolean              = true,
-    validIfIsRandom    : Boolean              = false,
-    rollbackBuffers    : Int                  = 4,
-    clockInfo          : Seq[ClockInfo]       = Seq.empty,
-    resetName          : String               = "reset",
-    noDefaultReset     : Boolean              = false,
-    symbolsToWatch     : Seq[String]          = Seq.empty
+    randomSeed        : Long                 = System.currentTimeMillis(),
+    blackBoxFactories : Seq[BlackBoxFactory] = Seq.empty,
+    maxExecutionDepth : Long                 = Int.MaxValue,
+    showFirrtlAtLoad  : Boolean              = false,
+    lowCompileAtLoad  : Boolean              = true,
+    validIfIsRandom   : Boolean              = false,
+    rollbackBuffers   : Int                  = 4,
+    clockInfo         : Seq[ClockInfo]       = Seq.empty,
+    resetName         : String               = "reset",
+    callResetAtStartUp: Boolean              = false,
+    symbolsToWatch    : Seq[String]          = Seq.empty
   )
   extends firrtl.ComposableOptions {
 
@@ -107,12 +107,12 @@ trait HasTreadleOptions {
     }
     .text("validIf returns random value when condition is false")
 
-  parser.opt[Unit]("no-default-reset")
-    .abbr("findr")
+  parser.opt[Unit]("call-reset-at-start")
+    .abbr("ficras")
     .foreach { _ =>
-      treadleOptions = treadleOptions.copy(noDefaultReset = true)
+      treadleOptions = treadleOptions.copy(callResetAtStartUp = true)
     }
-    .text("this prevents the tester from doing reset on it's own at startup")
+    .text("has the tester automatically do a reset on it's own at startup")
 
   parser.opt[Int]("fint-rollback-buffers")
     .abbr("firb")

--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -106,7 +106,7 @@ class TreadleTester(input: String, optionsManager: HasTreadleSuite = new Treadle
     )
   }
 
-  if(! optionsManager.treadleOptions.noDefaultReset && engine.symbolTable.contains("reset")) {
+  if(optionsManager.treadleOptions.callResetAtStartUp && engine.symbolTable.contains(resetName)) {
     clockInfoList.headOption.foreach { clockInfo =>
       reset(clockInfo.period + clockInfo.initialOffset)
 //      reset(clockInfo.period + clockInfo.initialOffset - (clockInfo.period / 2))
@@ -133,10 +133,11 @@ class TreadleTester(input: String, optionsManager: HasTreadleSuite = new Treadle
             engine.inputsChanged = true
             engine.evaluateCircuit()
           }
-          do {
+          while(engine.dataStore(resetSymbol) != Big0) {
             stepper.run(1)
-          } while(engine.dataStore(resetSymbol) != Big0)
-        case _ =>
+          }
+
+        case multiStepper =>
           clockStepper.addTask(wallTime.currentTime + timeRaised) { () =>
             engine.setValue(resetName, 0)
             if (engine.verbose) {
@@ -144,6 +145,7 @@ class TreadleTester(input: String, optionsManager: HasTreadleSuite = new Treadle
             }
             engine.inputsChanged = true
           }
+          wallTime.runUntil(wallTime.currentTime + timeRaised)
       }
     }
   }

--- a/src/test/scala/treadle/ClockSpec.scala
+++ b/src/test/scala/treadle/ClockSpec.scala
@@ -103,7 +103,7 @@ class ClockSpec extends FreeSpec with Matchers {
       treadleOptions = treadleOptions.copy(
         setVerbose = false,
         vcdShowUnderscored = true,
-        showFirrtlAtLoad = true,
+        showFirrtlAtLoad = false,
         writeVCD = false,
         validIfIsRandom = false
       )

--- a/src/test/scala/treadle/DynamicMemorySearch.scala
+++ b/src/test/scala/treadle/DynamicMemorySearch.scala
@@ -60,7 +60,7 @@ class DynamicMemorySearch extends FreeSpec with Matchers {
         writeVCD = false,
         vcdShowUnderscored = false,
         setVerbose = false,
-        showFirrtlAtLoad = true,
+        showFirrtlAtLoad = false,
         rollbackBuffers = 0,
         symbolsToWatch = Seq()
       )

--- a/src/test/scala/treadle/ExpressionRenderSpec.scala
+++ b/src/test/scala/treadle/ExpressionRenderSpec.scala
@@ -37,7 +37,7 @@ class ExpressionRenderSpec extends FreeSpec with Matchers {
         writeVCD = false,
         vcdShowUnderscored = false,
         setVerbose = false,
-        showFirrtlAtLoad = true,
+        showFirrtlAtLoad = false,
         rollbackBuffers = 0,
         symbolsToWatch = Seq()
       )

--- a/src/test/scala/treadle/MemoryUsageSpec.scala
+++ b/src/test/scala/treadle/MemoryUsageSpec.scala
@@ -116,8 +116,8 @@ class MemoryUsageSpec extends FreeSpec with Matchers {
     val optionsManager = new TreadleOptionsManager {
       treadleOptions = treadleOptions.copy(
         setVerbose = false,
-        showFirrtlAtLoad = true,
-        noDefaultReset = true
+        showFirrtlAtLoad = false,
+        callResetAtStartUp = true
       )
     }
     val tester = new TreadleTester(input, optionsManager) {
@@ -300,8 +300,8 @@ class MemoryUsageSpec extends FreeSpec with Matchers {
     val optionsManager = new TreadleOptionsManager {
       treadleOptions = treadleOptions.copy(
         setVerbose = false,
-        showFirrtlAtLoad = true,
-        noDefaultReset = true
+        showFirrtlAtLoad = false,
+        callResetAtStartUp = true
       )
     }
     val tester = new TreadleTester(input, optionsManager)
@@ -365,7 +365,7 @@ class MemoryUsageSpec extends FreeSpec with Matchers {
         treadleOptions = treadleOptions.copy(
           setVerbose = false,
           showFirrtlAtLoad = false,
-          noDefaultReset = true
+          callResetAtStartUp = true
         )
       }
       val tester = new TreadleTester(input, optionsManager)

--- a/src/test/scala/treadle/ModuleInLineSpec.scala
+++ b/src/test/scala/treadle/ModuleInLineSpec.scala
@@ -23,7 +23,7 @@ class ModuleInLineSpec extends FlatSpec with Matchers {
     val optionsManager = new TreadleOptionsManager {
       treadleOptions = treadleOptions.copy(
         setVerbose = false,
-        noDefaultReset = false
+        callResetAtStartUp = false
       )
     }
     val tester = TreadleTester(input, optionsManager)

--- a/src/test/scala/treadle/RegOfVecSpec.scala
+++ b/src/test/scala/treadle/RegOfVecSpec.scala
@@ -142,8 +142,8 @@ class RegOfVecSpec extends FreeSpec with Matchers {
         writeVCD = false,
         vcdShowUnderscored = true,
         setVerbose = false,
-        showFirrtlAtLoad = true,
-        noDefaultReset = true
+        showFirrtlAtLoad = false,
+        callResetAtStartUp = true
       )
     }
 

--- a/src/test/scala/treadle/RegisterSpec.scala
+++ b/src/test/scala/treadle/RegisterSpec.scala
@@ -26,8 +26,8 @@ class RegisterSpec extends FlatSpec with Matchers {
     val optionsManager = new TreadleOptionsManager {
       treadleOptions = treadleOptions.copy(
         setVerbose = false,
-        noDefaultReset = true,
-        showFirrtlAtLoad = true
+        callResetAtStartUp = true,
+        showFirrtlAtLoad = false
       )
     }
     val tester = TreadleTester(input, optionsManager)
@@ -82,7 +82,7 @@ class RegisterSpec extends FlatSpec with Matchers {
     val optionsManager = new TreadleOptionsManager {
       treadleOptions = treadleOptions.copy(
         setVerbose = false,
-        noDefaultReset = true
+        callResetAtStartUp = true
       )
     }
     val tester = TreadleTester(input, optionsManager)
@@ -188,7 +188,7 @@ class RegisterSpec extends FlatSpec with Matchers {
     val optionsManager = new TreadleOptionsManager {
       treadleOptions = treadleOptions.copy(
         setVerbose = false,
-        noDefaultReset = true,
+        callResetAtStartUp = true,
         writeVCD = false)
     }
     val tester = TreadleTester(input, optionsManager)
@@ -251,8 +251,8 @@ class RegisterSpec extends FlatSpec with Matchers {
     val optionsManager = new TreadleOptionsManager {
       treadleOptions = treadleOptions.copy(
         setVerbose = false,
-        noDefaultReset = true,
-        showFirrtlAtLoad = true,
+        callResetAtStartUp = true,
+        showFirrtlAtLoad = false,
         writeVCD = false
       )
     }
@@ -315,9 +315,9 @@ class RegisterSpec extends FlatSpec with Matchers {
 
     val manager = new TreadleOptionsManager {
       treadleOptions = treadleOptions.copy(
-        showFirrtlAtLoad = true,
+        showFirrtlAtLoad = false,
         setVerbose = false,
-        noDefaultReset = true,
+        callResetAtStartUp = true,
         writeVCD = false,
         rollbackBuffers = 15)
     }

--- a/src/test/scala/treadle/ShiftRegisterSpec.scala
+++ b/src/test/scala/treadle/ShiftRegisterSpec.scala
@@ -41,7 +41,7 @@ class ShiftRegisterSpec extends FreeSpec with Matchers {
         setVerbose = false,
         showFirrtlAtLoad = false,
         rollbackBuffers = 4,
-        noDefaultReset = true,
+        callResetAtStartUp = true,
         symbolsToWatch = Seq() // Seq("sr", "sr/in")
       )
     }

--- a/src/test/scala/treadle/StackSpec.scala
+++ b/src/test/scala/treadle/StackSpec.scala
@@ -85,7 +85,7 @@ class StackSpec extends FreeSpec with Matchers {
         writeVCD = false,
         vcdShowUnderscored = false,
         setVerbose = false,
-        showFirrtlAtLoad = true,
+        showFirrtlAtLoad = false,
         rollbackBuffers = 0,
         symbolsToWatch = Seq()
       )

--- a/src/test/scala/treadle/StopBehaviorSpec.scala
+++ b/src/test/scala/treadle/StopBehaviorSpec.scala
@@ -49,7 +49,7 @@ class StopBehaviorSpec extends FreeSpec with Matchers {
   "Stop should abort engine immediately" in {
     val optionsManager = new TreadleOptionsManager {
       treadleOptions = treadleOptions.copy(
-        noDefaultReset = true,
+        callResetAtStartUp = true,
         setVerbose = false
       )
     }

--- a/src/test/scala/treadle/blackboxes/BlackBoxWithState.scala
+++ b/src/test/scala/treadle/blackboxes/BlackBoxWithState.scala
@@ -46,7 +46,7 @@ class BlackBoxWithState extends FreeSpec with Matchers {
         writeVCD = false,
         symbolsToWatch = Seq("io_data"),
         blackBoxFactories = Seq(new AccumBlackBoxFactory),
-        noDefaultReset = false,
+        callResetAtStartUp = true,
         clockInfo = Seq(ClockInfo("clock", 10, -2))
       )
     }

--- a/src/test/scala/treadle/chronometry/MultiTopLevelClockSpec.scala
+++ b/src/test/scala/treadle/chronometry/MultiTopLevelClockSpec.scala
@@ -37,8 +37,8 @@ class MultiTopLevelClockSpec extends FreeSpec with Matchers {
       treadleOptions = treadleOptions.copy(
         setVerbose = false,
         clockInfo = Seq(ClockInfo("clock1", period = 17, 1000), ClockInfo("clock2", period = 19, initialOffset = 1017)),
-        showFirrtlAtLoad = true,
-        noDefaultReset = true,
+        showFirrtlAtLoad = false,
+        callResetAtStartUp = true,
         writeVCD = false
       )
     }

--- a/src/test/scala/treadle/primops/CatBitsHeadTail.scala
+++ b/src/test/scala/treadle/primops/CatBitsHeadTail.scala
@@ -96,7 +96,7 @@ class CatBitsHeadTail extends FreeSpec with Matchers {
             writeVCD = false,
             vcdShowUnderscored = false,
             setVerbose = false,
-            showFirrtlAtLoad = true,
+            showFirrtlAtLoad = false,
             rollbackBuffers = 0,
             symbolsToWatch = Seq()
           )

--- a/src/test/scala/treadle/primops/EqOpsTester.scala
+++ b/src/test/scala/treadle/primops/EqOpsTester.scala
@@ -58,8 +58,8 @@ class EqOpsTester extends FreeSpec with Matchers {
     val optionsManager = new TreadleOptionsManager {
       treadleOptions = treadleOptions.copy(
         setVerbose = false,
-        noDefaultReset = true,
-        showFirrtlAtLoad = true,
+        callResetAtStartUp = true,
+        showFirrtlAtLoad = false,
         blackBoxFactories = Seq(factory)
       )
     }
@@ -90,7 +90,7 @@ class EqOpsTester extends FreeSpec with Matchers {
         writeVCD = false,
         vcdShowUnderscored = false,
         setVerbose = false,
-        showFirrtlAtLoad = true,
+        showFirrtlAtLoad = false,
         rollbackBuffers = 0,
         symbolsToWatch = Seq()
       )


### PR DESCRIPTION
the external testing infra-structure

* Rename NoDefaultReset to callResetAtStartup and change the sense of it
* Change the menu options
* Change automatic reset call control
* Multi-stepper should run until reset is cleared