### PR TITLE
Make combinational logic take time

### DIFF
--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -71,6 +71,7 @@ class TreadleTester(input: String, optionsManager: HasTreadleSuite = new Treadle
         engine.symbolTable(clockInfo.name),
         engine.symbolTable.get(resetName),
         clockInfo.period,
+        clockInfo.initialOffset,
         wallTime
       )
     case _ =>

--- a/src/main/scala/treadle/executable/ClockStepper.scala
+++ b/src/main/scala/treadle/executable/ClockStepper.scala
@@ -26,6 +26,7 @@ case class SimpleSingleClockStepper(
   clockSymbol: Symbol,
   resetSymbolOpt: Option[Symbol],
   clockPeriod: Long,
+  clockInitialOffset: Long,
   wallTime: UTC
 ) extends ClockStepper {
 
@@ -52,7 +53,12 @@ case class SimpleSingleClockStepper(
       }
 
       cycleCount += 1
-      wallTime.incrementTime(downPeriod)
+
+      /*
+      This bit of code assumes any combinational delays occur after a down clock has happened.
+       */
+      val downIncrement = (wallTime.currentTime - clockInitialOffset) % clockPeriod
+      wallTime.incrementTime(downPeriod - downIncrement)
       if(resetTaskTime >= 0 && wallTime.currentTime >= resetTaskTime) {
         resetSymbolOpt.foreach { resetSymbol =>
           engine.setValue(resetSymbol.name, 0)

--- a/src/test/scala/treadle/CombinationalDelaySpec.scala
+++ b/src/test/scala/treadle/CombinationalDelaySpec.scala
@@ -1,0 +1,74 @@
+// See LICENSE for license details.
+
+package treadle
+
+import org.scalatest.{FreeSpec, Matchers}
+import treadle.executable.ClockInfo
+
+//scalastyle:off magic.number
+class CombinationalDelaySpec extends FreeSpec with Matchers {
+  private val input =
+    """
+      |circuit CombinationalCircuit :
+      |
+      |  module CombinationalCircuit :
+      |    input clock    : Clock
+      |    input reset    : SInt<16>
+      |    input in_0     : SInt<16>
+      |    input in_1     : SInt<16>
+      |    output add_out : SInt<16>
+      |    output sub_out : SInt<16>
+      |    output eq_out  : UInt<1>
+      |
+      |    add_out <= add(in_0, in_1)
+      |    sub_out <= sub(in_0, in_1)
+      |    eq_out  <= eq(in_0, in_1)
+      |
+    """.stripMargin
+
+  "combinational delay takes 100th of period to execute" in {
+    val optionsManager = new TreadleOptionsManager {
+      treadleOptions = treadleOptions.copy(
+        writeVCD = true,
+        clockInfo = Seq(ClockInfo("clock", period = 1000L, initialOffset = 0)),
+        vcdShowUnderscored = false,
+        setVerbose = false,
+        showFirrtlAtLoad = false,
+        rollbackBuffers = 0,
+        symbolsToWatch = Seq()
+      )
+    }
+
+    val t = new TreadleTester(input, optionsManager)
+    t.poke("in_0", 20)
+    t.poke("in_1", 11)
+    t.expect("add_out", 31)
+    t.expect("sub_out", 9)
+    t.expect("eq_out", 0)
+
+    assert(t.wallTime.currentTime == 10)
+
+    t.poke("in_0", 5)
+    t.poke("in_1", 25)
+    t.expect("add_out", 30)
+    t.expect("sub_out", -20)
+    t.expect("eq_out", 0)
+
+    assert(t.wallTime.currentTime == 20)
+
+    t.poke("in_0", 5)
+    t.poke("in_1", 5)
+    t.expect("add_out", 10)
+    t.expect("sub_out", 0)
+    t.expect("eq_out", 1)
+
+    assert(t.wallTime.currentTime == 30)
+
+    t.step()
+
+    assert(t.wallTime.currentTime == 1000)
+
+    t.report()
+
+  }
+}


### PR DESCRIPTION
now takes combinational delay which is generally
clock period / 100
If clock period set high enough for this to be non-zero
then the combinational logic can be viewed in vcd