### PR TITLE
Fixed the watch list of symbols that shows their computation

### DIFF
--- a/src/main/scala/treadle/Driver.scala
+++ b/src/main/scala/treadle/Driver.scala
@@ -143,6 +143,14 @@ trait HasTreadleOptions {
     }
     .text("clock-name[:period[:initial-offset]]")
 
+  parser.opt[Seq[String]]("fint-symbols-to-watch")
+    .abbr("fistw")
+    .valueName("symbols]")
+    .foreach { x =>
+    treadleOptions = treadleOptions.copy(symbolsToWatch = x)
+    }
+    .text("symbol[,symbol[...]")
+
   parser.opt[String]("fint-reset-name")
     .abbr("firn")
     .valueName("<string>")

--- a/src/main/scala/treadle/ExecutionEngine.scala
+++ b/src/main/scala/treadle/ExecutionEngine.scala
@@ -43,12 +43,12 @@ class ExecutionEngine(
 
   dataStore.addPlugin(
     "show-computation",
-    new RenderComputations(this),
+    new RenderComputations(this, optionsManager.treadleOptions.symbolsToWatch),
     enable = optionsManager.treadleOptions.symbolsToWatch.nonEmpty
   )
 
   def setLeanMode(): Unit = {
-    val canBeLean = ! (verbose || vcdOption.isDefined)
+    val canBeLean = ! (verbose || dataStore.hasEnabledPlugins)
     scheduler.setLeanMode(canBeLean)
     scheduler.setVerboseAssign(verbose)
   }
@@ -114,8 +114,6 @@ class ExecutionEngine(
       vcd.write(vcdFileName)
     }
   }
-
-  setVerbose(interpreterOptions.setVerbose)
 
   def renderComputation(symbolNames: String, outputFormat: String = "d"): String = {
     val renderer = new ExpressionViewRenderer(dataStore, symbolTable, expressionViews)

--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -89,8 +89,7 @@ class TreadleTester(input: String, optionsManager: HasTreadleSuite = new Treadle
       case s: SimpleSingleClockStepper =>
         s.clockPeriod / 100
       case m: MultiClockStepper =>
-        // TODO (chick) Make this more meaningful
-        0
+        m.shortestPeriod / 100
       case _ =>
         0
     }
@@ -138,7 +137,7 @@ class TreadleTester(input: String, optionsManager: HasTreadleSuite = new Treadle
             stepper.run(1)
           }
 
-        case multiStepper =>
+        case _ =>
           clockStepper.addTask(wallTime.currentTime + timeRaised) { () =>
             engine.setValue(resetName, 0)
             if (engine.verbose) {

--- a/src/main/scala/treadle/executable/ClockStepper.scala
+++ b/src/main/scala/treadle/executable/ClockStepper.scala
@@ -102,6 +102,8 @@ class MultiClockStepper(engine: ExecutionEngine, clockInfoList: Seq[ClockInfo], 
   val dataStore: DataStore = engine.dataStore
   val scheduler: Scheduler = engine.scheduler
 
+  val shortestPeriod: Long = clockInfoList.map(_.period).min
+
   clockInfoList.foreach { clockInfo =>
     val clockSymbol = engine.symbolTable(clockInfo.name)
 

--- a/src/main/scala/treadle/executable/DataStore.scala
+++ b/src/main/scala/treadle/executable/DataStore.scala
@@ -38,6 +38,20 @@ class DataStore(val numberOfBuffers: Int, optimizationLevel: Int = 0) {
     plugin.setEnabled(enable)
   }
 
+  def enablePlugin(name: String): Unit = {
+    if(plugins.contains(name)) {
+      println(s"Could not find plugin $name to remove it")
+    }
+    plugins(name).setEnabled(true)
+  }
+
+  def disablePlugin(name: String): Unit = {
+    if(plugins.contains(name)) {
+      println(s"Could not find plugin $name to remove it")
+    }
+    plugins(name).setEnabled(false)
+  }
+
   def removePlugin(name: String): Unit = {
     if(plugins.contains(name)) {
       println(s"Could not find plugin $name to remove it")
@@ -45,6 +59,10 @@ class DataStore(val numberOfBuffers: Int, optimizationLevel: Int = 0) {
     val plugin = plugins(name)
     plugin.setEnabled(false)  // remove from active and should return to lean mode if no other plugins are active
     plugins.remove(name)
+  }
+
+  def hasEnabledPlugins: Boolean = {
+    activePlugins.nonEmpty
   }
 
   var executionEngineOption: Option[ExecutionEngine] = None

--- a/src/main/scala/treadle/executable/DataStorePlugIn.scala
+++ b/src/main/scala/treadle/executable/DataStorePlugIn.scala
@@ -9,6 +9,7 @@ abstract class DataStorePlugin {
   def executionEngine: ExecutionEngine
   def dataStore: DataStore
   var isEnabled: Boolean = false
+
   def setEnabled(enabled: Boolean): Unit = {
     isEnabled = enabled
     (isEnabled, dataStore.activePlugins.contains(this)) match {
@@ -47,11 +48,18 @@ class ReportAssignments(val executionEngine: ExecutionEngine) extends DataStoreP
   }
 }
 
-class RenderComputations(val executionEngine: ExecutionEngine) extends DataStorePlugin {
+class RenderComputations(
+  val executionEngine: ExecutionEngine,
+  symbolNamesToWatch: Seq[String]
+) extends DataStorePlugin {
+
   val dataStore: DataStore = executionEngine.dataStore
+  val symbolsToWatch: Set[Symbol] = symbolNamesToWatch.flatMap { name =>
+    executionEngine.symbolTable.get(name)
+  }.toSet
 
   def run(symbol: Symbol, offset: Int = -1): Unit = {
-    dataStore.executionEngineOption.foreach { executionEngine =>
+    if(symbolsToWatch.contains(symbol)) {
       println(executionEngine.renderComputation(symbol.name))
     }
   }

--- a/src/main/scala/treadle/executable/RenderedExpression.scala
+++ b/src/main/scala/treadle/executable/RenderedExpression.scala
@@ -138,7 +138,7 @@ class ExpressionViewRenderer(
           val value = symbol.normalize(dataStore.earlierValue(symbol, lookBackDepth))
 
           val string = s"${symbol.name}" + (if(showValues) {
-             "<= " +
+             " <= " +
                     (if(lookBackDepth > 0) Console.RED else "") +
                     s"${formatOutput(value)}" +
                     (if(lookBackDepth > 0) Console.RESET else "")

--- a/src/test/scala/treadle/GCDTester.scala
+++ b/src/test/scala/treadle/GCDTester.scala
@@ -63,7 +63,7 @@ class GCDTester extends FlatSpec with Matchers {
     }
 
     val values =
-      for {x <- 10 to 1000
+      for {x <- 100 to 1000
            y <- 10 to 100
       } yield (x, y, computeGcd(x, y)._1)
 

--- a/src/test/scala/treadle/RegisterCycleTest.scala
+++ b/src/test/scala/treadle/RegisterCycleTest.scala
@@ -2,8 +2,11 @@
 
 package treadle
 
-import org.scalatest.{Matchers, FreeSpec}
+import java.io.{ByteArrayOutputStream, PrintStream}
 
+import org.scalatest.{FreeSpec, Matchers}
+
+//scalastyle:off magic.number
 class RegisterCycleTest extends FreeSpec with Matchers {
   "cycle behavior test-only intepreter should not crash on various register init methods" - {
     "method 1" in {
@@ -82,13 +85,18 @@ class RegisterCycleTest extends FreeSpec with Matchers {
           |
         """.stripMargin
 
+      val output = new ByteArrayOutputStream()
+      Console.withOut(new PrintStream(output)) {
+        val optionsManager = new TreadleOptionsManager
+        optionsManager.parser.parse(Array("-fistw", "io_Out,mySubModule_1.io_Out"))
 
-      val tester = new TreadleTester(input)
-      // tester.setVerbose()
+        val tester = new TreadleTester(input, optionsManager)
+        tester.poke("io_In", 1)
+        tester.step(3)
+        tester.expect("io_Out", 1)
+      }
 
-      tester.poke("io_In", 1)
-      tester.step(3)
-      tester.expect("io_Out", 1)
+      output.toString.contains("io_Out <= 1") should be (true)
     }
   }
 


### PR DESCRIPTION
* Added methods to query enabled, enable and disable plug-ins
* Cleaned up render computation, keeps set and it already had engine ref
* Options parser did not pick up symbols to watch from command line
* removed extraneous setVerbose call
* tested that watched symbol was rendered
* Shorten some gcd tests
* Fixed combinational delay not being set above zero with multi-clock