### PR TITLE
Roll back refactor

### DIFF
--- a/src/main/scala/treadle/ExecutionEngine.scala
+++ b/src/main/scala/treadle/ExecutionEngine.scala
@@ -340,7 +340,6 @@ class ExecutionEngine(
     val keys = symbolTable.keys.toArray.sorted
 
     ("-" * fieldsHeader.length) + "\n" +
-      f"${dataStore.currentBufferIndex}%2s  " +
         keys.map { name =>
           val symbol = symbolTable(name)
           val value = symbol.normalize(dataStore(symbolTable(name)))

--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -25,17 +25,16 @@ class TreadleTester(input: String, optionsManager: HasTreadleSuite = new Treadle
 
   treadle.random.setSeed(optionsManager.treadleOptions.randomSeed)
 
-  val engine         : ExecutionEngine  = ExecutionEngine(input, optionsManager)
-  val treadleOptions : TreadleOptions   = optionsManager.treadleOptions
-
-  val resetName: String = treadleOptions.resetName
-
   val wallTime = UTC()
   wallTime.onTimeChange = () => {
     engine.vcdOption.foreach { vcd =>
       vcd.setTime(wallTime.currentTime)}
   }
 
+  val engine         : ExecutionEngine  = ExecutionEngine(input, optionsManager, wallTime)
+  val treadleOptions : TreadleOptions   = optionsManager.treadleOptions
+
+  val resetName: String = treadleOptions.resetName
   def setVerbose(value: Boolean = true): Unit = {
     engine.setVerbose(value)
   }
@@ -239,7 +238,7 @@ class TreadleTester(input: String, optionsManager: HasTreadleSuite = new Treadle
     if(value != expectedValue) {
       val renderer = new ExpressionViewRenderer(
         engine.dataStore, engine.symbolTable, engine.expressionViews)
-      val calculation = renderer.render(engine.symbolTable(name))
+      val calculation = renderer.render(engine.symbolTable(name), wallTime.currentTime)
       fail(new TreadleException (s"Error:expect($name, $expectedValue) got $value $message\n$calculation"))
     }
     expectationsMet += 1
@@ -294,7 +293,7 @@ class TreadleTester(input: String, optionsManager: HasTreadleSuite = new Treadle
     if(value != expectedValue) {
       val renderer = new ExpressionViewRenderer(
         engine.dataStore, engine.symbolTable, engine.expressionViews)
-      val calculation = renderer.render(engine.symbolTable(name))
+      val calculation = renderer.render(engine.symbolTable(name), wallTime.currentTime)
       fail(new TreadleException (s"Error:expect($name, $expectedValue) got $value $message\n$calculation"))
     }
     expectationsMet += 1

--- a/src/main/scala/treadle/chronometry/UTC.scala
+++ b/src/main/scala/treadle/chronometry/UTC.scala
@@ -4,7 +4,7 @@ package treadle.chronometry
 
 import scala.collection.mutable
 
-class UTC private (scaleName: String = "picoseconds") {
+class UTC(scaleName: String = "picoseconds") {
   private var internalTime: Long = 0L
   def currentTime:  Long = internalTime
   def setTime(time: Long): Unit = {

--- a/src/main/scala/treadle/executable/IntOps.scala
+++ b/src/main/scala/treadle/executable/IntOps.scala
@@ -247,7 +247,7 @@ case class TailInts(f1: FuncInt, toDrop: Int, originalWidth: Int) extends IntExp
 
 case class IsPosEdge(symbol: Symbol, symbolPreviousValue: Symbol, dataStore: DataStore) extends IntExpressionResult {
   def apply(): Int = {
-    if(dataStore.currentIntArray(symbol.index) == 1 && dataStore.currentIntArray(symbolPreviousValue.index) == 0) {
+    if(dataStore.intData(symbol.index) == 1 && dataStore.intData(symbolPreviousValue.index) == 0) {
       1
     }
     else {

--- a/src/main/scala/treadle/executable/RollBackBuffer.scala
+++ b/src/main/scala/treadle/executable/RollBackBuffer.scala
@@ -2,6 +2,8 @@
 
 package treadle.executable
 
+import scala.collection.mutable
+
 class RollBackBuffer(intSize: Int, longSize: Int, bigIntSize: Int) {
   var time: Long = 0L
   var associatedClock: String = ""
@@ -18,8 +20,20 @@ class RollBackBuffer(intSize: Int, longSize: Int, bigIntSize: Int) {
     assert(bigData.length == bigs.length,
       s"RollBackBuffer.dump size error source ${bigs.length} target ${bigData.length}")
 
-    Array.copy(ints, 0, intData, 0, intData.length)
+    Array.copy(ints,  0, intData,  0, intData.length)
     Array.copy(longs, 0, longData, 0, longData.length)
-    Array.copy(bigs, 0, bigData, 0, bigData.length)
+    Array.copy(bigs,  0, bigData,  0, bigData.length)
   }
+}
+
+class RollBackBufferManager(numberOfRollBackBuffers: Int) {
+  val clockToBuffers: mutable.HashMap[String, Seq[RollBackBuffer]] = new mutable.HashMap()
+
+  def dump(clockName: String, time: Long, dataStore: DataStore): Unit = {
+
+  }
+
+  def backupDepth: Int = ???
+
+
 }

--- a/src/main/scala/treadle/executable/RollBackBuffer.scala
+++ b/src/main/scala/treadle/executable/RollBackBuffer.scala
@@ -4,36 +4,83 @@ package treadle.executable
 
 import scala.collection.mutable
 
-class RollBackBuffer(intSize: Int, longSize: Int, bigIntSize: Int) {
+class RollBackBuffer(dataStore: DataStore) extends HasDataArrays {
   var time: Long = 0L
-  var associatedClock: String = ""
 
-  val intData    : Array[Int]  = Array.fill(intSize)(0)
-  val longData   : Array[Long] = Array.fill(longSize)(0)
-  val bigData    : Array[Big]  = Array.fill(bigIntSize)(0)
+  val intData    : Array[Int]  = Array.fill(dataStore.numberOfInts)(0)
+  val longData   : Array[Long] = Array.fill(dataStore.numberOfLongs)(0)
+  val bigData    : Array[Big]  = Array.fill(dataStore.numberOfBigs)(0)
 
-  def dump(dumpTime: Long, ints: Array[Int], longs: Array[Long], bigs: Array[Big]): Unit = {
-    assert(intData.length == ints.length,
-      s"RollBackBuffer.dump size error source ${ints.length} target ${intData.length}")
-    assert(longData.length == longs.length,
-      s"RollBackBuffer.dump size error source ${longs.length} target ${longData.length}")
-    assert(bigData.length == bigs.length,
-      s"RollBackBuffer.dump size error source ${bigs.length} target ${bigData.length}")
-
-    Array.copy(ints,  0, intData,  0, intData.length)
-    Array.copy(longs, 0, longData, 0, longData.length)
-    Array.copy(bigs,  0, bigData,  0, bigData.length)
+  def dump(dumpTime: Long): Unit = {
+    time = dumpTime
+    Array.copy(dataStore.intData,  0, intData,  0, intData.length)
+    Array.copy(dataStore.longData, 0, longData, 0, longData.length)
+    Array.copy(dataStore.bigData,  0, bigData,  0, bigData.length)
   }
 }
 
-class RollBackBufferManager(numberOfRollBackBuffers: Int) {
-  val clockToBuffers: mutable.HashMap[String, Seq[RollBackBuffer]] = new mutable.HashMap()
+class RollBackBufferRing(dataStore: DataStore) {
+  val numberOfBuffers: Int = dataStore.numberOfBuffers
+  val ringBuffer: Array[RollBackBuffer] = Array.fill(dataStore.numberOfBuffers)(new RollBackBuffer(dataStore))
 
-  def dump(clockName: String, time: Long, dataStore: DataStore): Unit = {
+  var oldestBufferIndex: Int = 0
+  var latestBufferIndex: Int = 0
 
+  def currentNumberOfBuffers: Int = (latestBufferIndex + numberOfBuffers - oldestBufferIndex) % numberOfBuffers
+
+  def newestToOldestBuffers: Seq[RollBackBuffer] = {
+    var list = List.empty[RollBackBuffer]
+    var index = latestBufferIndex
+    while(index != oldestBufferIndex) {
+      list = list :+ ringBuffer(index)
+      index -= 1
+      if(index < 0) {
+        index = numberOfBuffers - 1
+      }
+    }
+    list
   }
 
-  def backupDepth: Int = ???
+  def advanceAndGetNextBuffer(): RollBackBuffer = {
+    latestBufferIndex += 1
+    if(latestBufferIndex >= numberOfBuffers) {
+      latestBufferIndex = 0
+    }
+    if(latestBufferIndex == oldestBufferIndex) {
+      oldestBufferIndex += 1
+      if(oldestBufferIndex >= numberOfBuffers) {
+        oldestBufferIndex = 0
+      }
+    }
+    ringBuffer(latestBufferIndex)
+  }
+}
 
+/**
+  * Manage a number of rollback buffers for each clock
+  */
+class RollBackBufferManager(dataStore: DataStore) {
 
+  val clockToBuffers: mutable.HashMap[String, RollBackBufferRing] = new mutable.HashMap()
+
+  def saveData(clockName: String, time: Long): Unit = {
+    val buffer: RollBackBuffer = {
+      if(! clockToBuffers.contains(clockName)) {
+        clockToBuffers(clockName) = new RollBackBufferRing(dataStore)
+      }
+      clockToBuffers(clockName).advanceAndGetNextBuffer()
+    }
+    buffer.dump(time)
+  }
+
+  def findEarlierBuffer(clockName: String, time: Long): Option[RollBackBuffer] = {
+    clockToBuffers.get(clockName) match {
+      case Some(rollBackBufferRing) =>
+        rollBackBufferRing.newestToOldestBuffers.find { buffer =>
+          buffer.time < time
+        }
+      case _ =>
+        None
+    }
+  }
 }

--- a/src/main/scala/treadle/executable/Scheduler.scala
+++ b/src/main/scala/treadle/executable/Scheduler.scala
@@ -183,7 +183,9 @@ class Scheduler(val symbolTable: SymbolTable) extends LazyLogging {
     */
   def render(engine: ExecutionEngine): String = {
     def renderAssigner(assigner: Assigner): String = {
-      val expression = engine.expressionViewRenderer.render(assigner.symbol, showValues = false)
+      val expression =
+        engine.expressionViewRenderer.render(assigner.symbol, engine.wallTime.currentTime, showValues = false)
+
       if(expression.isEmpty) {
         s"${assigner.symbol.name} :::"
       }

--- a/src/test/scala/treadle/ExpressionRenderSpec.scala
+++ b/src/test/scala/treadle/ExpressionRenderSpec.scala
@@ -55,4 +55,61 @@ class ExpressionRenderSpec extends FreeSpec with Matchers {
     println(t.engine.renderComputation("out"))
   }
 
+  "ExpressionRenderSpec show register values from previous time" in {
+    val input =
+      """
+        |circuit DynamicMemorySearch :
+        |  module DynamicMemorySearch :
+        |    input clock : Clock
+        |    input reset : UInt<1>
+        |    input in0 : UInt<16>
+        |    output out0 : UInt<16>
+        |    output out1 : UInt<16>
+        |    output out2 : UInt<16>
+        |    output out3 : UInt<16>
+        |
+        |    reg r1 : UInt<16>, clock
+        |    reg r2 : UInt<16>, clock
+        |    reg r3 : UInt<16>, clock
+        |
+        |    r1 <= in0
+        |    r2 <= r1
+        |    r3 <= r2
+        |
+        |    out0 <= in0
+        |    out1 <= r1
+        |    out2 <= r2
+        |    out3 <= r3
+        |
+      """.stripMargin
+
+    val optionsManager = new TreadleOptionsManager {
+      treadleOptions = treadleOptions.copy(
+        writeVCD = false,
+        vcdShowUnderscored = false,
+        setVerbose = true,
+        showFirrtlAtLoad = false,
+        rollbackBuffers = 10,
+        symbolsToWatch = Seq()
+      )
+    }
+
+    val t = new TreadleTester(input, optionsManager)
+    t.poke("in0", 1)
+    t.step()
+    t.poke("in0", 2)
+    t.step()
+    t.poke("in0", 3)
+    t.step()
+    t.poke("in0", 4)
+    t.step()
+    t.poke("in0", 5)
+    t.step()
+
+    println(t.engine.renderComputation("out0"))
+    println(t.engine.renderComputation("r1"))
+    println(t.engine.renderComputation("r2"))
+    println(t.engine.renderComputation("r3"))
+  }
+
 }

--- a/src/test/scala/treadle/SnapshotSpec.scala
+++ b/src/test/scala/treadle/SnapshotSpec.scala
@@ -16,13 +16,13 @@ class SnapshotSpec extends FreeSpec with Matchers {
         |    input reset : UInt<1>
         |    input in0 : UInt<16>
         |    output out0 : UInt<16>
-        |    output out1 : UInt<16>
-        |    output out2 : UInt<16>
-        |    output out3 : UInt<16>
+        |    output out1 : UInt<44>
+        |    output out2 : UInt<128>
+        |    output out3 : UInt<128>
         |
         |    reg r1 : UInt<16>, clock
-        |    reg r2 : UInt<16>, clock
-        |    reg r3 : UInt<16>, clock
+        |    reg r2 : UInt<44>, clock
+        |    reg r3 : UInt<128>, clock
         |
         |    r1 <= in0
         |    r2 <= r1
@@ -52,16 +52,28 @@ class SnapshotSpec extends FreeSpec with Matchers {
     t.poke("in0", 2)
     t.step()
     t.poke("in0", 3)
+
+    val snapshot0 = t.engine.dataStore.serialize
+
     t.step()
     t.poke("in0", 4)
     t.step()
     t.poke("in0", 5)
     t.step()
 
-    val jsonOut = t.engine.dataStore.serialize
-    jsonOut.contains(""""numberOfBuffers":4,""") should be (true)
-    jsonOut.contains(""""clockName":"clock",""") should be (true)
+    val snapshot1 = t.engine.dataStore.serialize
+    snapshot1.contains(""""numberOfBuffers":4,""") should be (true)
+    snapshot1.contains(""""clockName":"clock",""") should be (true)
 
-    println(s"datastore snapshot\n${t.engine.dataStore.serialize}")
+    println(s"snapshot0\n$snapshot0")
+    println(s"snapshot1\n$snapshot1")
+
+    t.engine.dataStore.deserialize(snapshot0)
+
+    val snapshot2 = t.engine.dataStore.serialize
+
+    snapshot2 should be (snapshot0)
+
+    println(s"snapshot2\n$snapshot2")
   }
 }

--- a/src/test/scala/treadle/SnapshotSpec.scala
+++ b/src/test/scala/treadle/SnapshotSpec.scala
@@ -1,0 +1,67 @@
+// See LICENSE for license details.
+
+package treadle
+
+import org.scalatest.{FreeSpec, Matchers}
+
+
+// scalastyle:off magic.number
+class SnapshotSpec extends FreeSpec with Matchers {
+  "Snapshots can be created" in {
+    val input =
+      """
+        |circuit SnapShotExample :
+        |  module SnapShotExample :
+        |    input clock : Clock
+        |    input reset : UInt<1>
+        |    input in0 : UInt<16>
+        |    output out0 : UInt<16>
+        |    output out1 : UInt<16>
+        |    output out2 : UInt<16>
+        |    output out3 : UInt<16>
+        |
+        |    reg r1 : UInt<16>, clock
+        |    reg r2 : UInt<16>, clock
+        |    reg r3 : UInt<16>, clock
+        |
+        |    r1 <= in0
+        |    r2 <= r1
+        |    r3 <= r2
+        |
+        |    out0 <= in0
+        |    out1 <= r1
+        |    out2 <= r2
+        |    out3 <= r3
+        |
+      """.stripMargin
+
+    val optionsManager = new TreadleOptionsManager {
+      treadleOptions = treadleOptions.copy(
+        writeVCD = false,
+        vcdShowUnderscored = false,
+        setVerbose = false,
+        showFirrtlAtLoad = false,
+        rollbackBuffers = 4,
+        symbolsToWatch = Seq()
+      )
+    }
+
+    val t = new TreadleTester(input, optionsManager)
+    t.poke("in0", 1)
+    t.step()
+    t.poke("in0", 2)
+    t.step()
+    t.poke("in0", 3)
+    t.step()
+    t.poke("in0", 4)
+    t.step()
+    t.poke("in0", 5)
+    t.step()
+
+    val jsonOut = t.engine.dataStore.serialize
+    jsonOut.contains(""""numberOfBuffers":4,""") should be (true)
+    jsonOut.contains(""""clockName":"clock",""") should be (true)
+
+    println(s"datastore snapshot\n${t.engine.dataStore.serialize}")
+  }
+}

--- a/src/test/scala/treadle/VecSpec.scala
+++ b/src/test/scala/treadle/VecSpec.scala
@@ -40,12 +40,9 @@ class VecSpec extends FreeSpec with Matchers {
     }
 
     val tester = new TreadleTester(input, optionsManager)
-//
-//    tester.poke("reset", 1)
-//    tester.step()
-//    tester.poke("reset", 0)
 
     def show(): Unit = {
+      println("")
       for(name <- Seq("shifter_3", "shifter_2", "shifter_1", "shifter_0")) {
         println(s"${tester.engine.renderComputation(name)}")
       }

--- a/src/test/scala/treadle/executable/SymbolTableSpec.scala
+++ b/src/test/scala/treadle/executable/SymbolTableSpec.scala
@@ -7,6 +7,7 @@ import firrtl.graph.CyclicException
 import firrtl.transforms.DontCheckCombLoopsAnnotation
 import treadle._
 import org.scalatest.{FreeSpec, Matchers}
+import treadle.chronometry.UTC
 
 //scalastyle:off magic.number
 class SymbolTableSpec extends FreeSpec with Matchers {
@@ -38,7 +39,8 @@ class SymbolTableSpec extends FreeSpec with Matchers {
         .stripMargin
 
     val optionsManager = new TreadleOptionsManager
-    val simulator = ExecutionEngine(simpleFirrtl, optionsManager)
+    val wallTime = new UTC()
+    val simulator = ExecutionEngine(simpleFirrtl, optionsManager, wallTime)
 
     val symbolTable = simulator.symbolTable
 


### PR DESCRIPTION

* Now, number of rollbacks is per clock
* save state happens before a clock goes high
* DataStore only stores current time values
  * history day now in rollback buffers with a manager
  * DataStore layout now computed with an allocator so
  * arrays don't have to be vars
  * snap shot disabled at moment
* RenderedExpressions refactored
  * now time based.
* Symbol table now can identify a registers clock name
* Added a test for register rendering

Along the way
* Clock constructor not private anymore
* wall time had to be accessible to engine for rendering purposes