### PR TITLE
Add mill support

### DIFF
--- a/CommonBuild.sc
+++ b/CommonBuild.sc
@@ -1,0 +1,29 @@
+def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
+  Seq() ++ {
+    // If we're building with Scala > 2.11, enable the compile option
+    //  switch to support our anonymous Bundle definitions:
+    //  https://github.com/scala/bug/issues/10047
+    if (scalaVersion.startsWith("2.11.")) {
+      Seq()
+    } else {
+      Seq(
+        "-Xsource:2.11",
+        "-Ywarn-unused:imports",
+        "-Ywarn-unused:locals"
+      )
+    }
+  }
+}
+
+def javacOptionsVersion(scalaVersion: String): Seq[String] = {
+  Seq() ++ {
+    // Scala 2.12 requires Java 8. We continue to generate
+    //  Java 7 compatible code for Scala 2.11
+    //  for compatibility with old clients.
+    if (scalaVersion.startsWith("2.11.")) {
+      Seq("-source", "1.7", "-target", "1.7")
+    } else {
+      Seq("-source", "1.8", "-target", "1.8")
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+root_dir ?= $(PWD)
+
+SBT ?= sbt
+SBT_FLAGS ?= -Dsbt.log.noformat=true
+MKDIR ?= mkdir -p
+CURL ?= curl -L
+MILL_BIN ?= $(HOME)/bin/mill
+MILL ?= $(MILL_BIN) --color false
+
+# Ensure the default target is something reasonable.
+default: build
+
+# Fetch mill (if we don't have it.
+$(MILL_BIN):
+	$(MKDIR) $(dir $@)
+	$(CURL) -o $@ https://github.com/ucbjrl/mill/releases/download/v0.2.0-FDF/mill-0.2.0-FDF && chmod +x $@
+
+mill-tools:	$(MILL_BIN)
+
+# Compile and package jar
+mill.build: mill-tools
+	$(MILL) firrtlInterpreter.jar
+
+# Compile and test
+mill.test: mill-tools
+	$(MILL) firrtlInterpreter.test
+
+# Build and publish jar
+mill.publishLocal: mill-tools
+	$(MILL) firrtlInterpreter.publishLocal
+
+# Compile and package all jar
+mill.build.all: mill-tools
+	$(MILL) firrtlInterpreter[_].jar
+
+# Compile and test
+mill.test.all: mill-tools
+	$(MILL) firrtlInterpreter[_].test
+
+# Build and publish jar
+mill.publishLocal.all: mill-tools
+	$(MILL) firrtlInterpreter[_].publishLocal
+
+# Remove all generated code.
+# Until "mill clean" makes it into a release.
+mill.clean:
+	$(RM) -rf out
+
+clean:	mill.clean
+	$(SBT) "+clean"
+
+build:	mill.build
+
+.PHONY: build clean mill.build mill.test mill.publishLocal mill.build.all mill.test.all mill.publishLocal.all

--- a/Makefile
+++ b/Makefile
@@ -19,27 +19,27 @@ mill-tools:	$(MILL_BIN)
 
 # Compile and package jar
 mill.build: mill-tools
-	$(MILL) firrtlInterpreter.jar
+	$(MILL) treadle.jar
 
 # Compile and test
 mill.test: mill-tools
-	$(MILL) firrtlInterpreter.test
+	$(MILL) treadle.test
 
 # Build and publish jar
 mill.publishLocal: mill-tools
-	$(MILL) firrtlInterpreter.publishLocal
+	$(MILL) treadle.publishLocal
 
 # Compile and package all jar
 mill.build.all: mill-tools
-	$(MILL) firrtlInterpreter[_].jar
+	$(MILL) treadle[_].jar
 
 # Compile and test
 mill.test.all: mill-tools
-	$(MILL) firrtlInterpreter[_].test
+	$(MILL) treadle[_].test
 
 # Build and publish jar
 mill.publishLocal.all: mill-tools
-	$(MILL) firrtlInterpreter[_].publishLocal
+	$(MILL) treadle[_].publishLocal
 
 # Remove all generated code.
 # Until "mill clean" makes it into a release.

--- a/build.sc
+++ b/build.sc
@@ -1,0 +1,96 @@
+import ammonite.ops._
+import ammonite.ops.ImplicitWd._
+import mill._
+import mill.scalalib._
+import mill.scalalib.publish._
+import mill.eval.Evaluator
+
+import $file.CommonBuild
+
+// An sbt layout with src in the top directory.
+trait CrossUnRootedSbtModule extends CrossSbtModule {
+  override def millSourcePath = super.millSourcePath / ammonite.ops.up
+}
+
+trait CommonModule extends CrossUnRootedSbtModule with PublishModule {
+  def publishVersion = "1.2-SNAPSHOT"
+
+  def pomSettings = PomSettings(
+    description = artifactName(),
+    organization = "edu.berkeley.cs",
+    url = "https://github.com/freechipsproject/firrtl-interpreter.git",
+    licenses = Seq(License.`BSD-3-Clause`),
+    versionControl = VersionControl.github("freechipsproject", "firrtl-interpreter"),
+    developers = Seq(
+      Developer("chick",    "Charles Markley",      "https://aspire.eecs.berkeley.edu/author/chick/")
+    )
+  )
+
+  override def scalacOptions = Seq(
+    "-deprecation",
+    "-explaintypes",
+    "-feature", "-language:reflectiveCalls",
+    "-unchecked",
+    "-Xcheckinit",
+    "-Xlint:infer-any",
+    "-Xlint:missing-interpolator"
+  ) ++ CommonBuild.scalacOptionsVersion(crossScalaVersion)
+
+  override def javacOptions = CommonBuild.javacOptionsVersion(crossScalaVersion)
+}
+
+val crossVersions = Seq("2.11.12", "2.12.4")
+
+// Make this available to external tools.
+object firrtlInterpreter extends Cross[FirrtlInterpreterModule](crossVersions: _*) {
+  def defaultVersion(ev: Evaluator[Any]) = T.command{
+    println(crossVersions.head)
+  }
+
+  def compile = T{
+    firrtlInterpreter(crossVersions.head).compile()
+  }
+
+  def jar = T{
+    firrtlInterpreter(crossVersions.head).jar()
+  }
+
+  def test = T{
+    firrtlInterpreter(crossVersions.head).test.test()
+  }
+
+  def publishLocal = T{
+    firrtlInterpreter(crossVersions.head).publishLocal()
+  }
+
+  def docJar = T{
+    firrtlInterpreter(crossVersions.head).docJar()
+  }
+}
+
+// Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
+val defaultVersions = Map("firrtl" -> "1.2-SNAPSHOT")
+
+def getVersion(dep: String, org: String = "edu.berkeley.cs") = {
+  val version = sys.env.getOrElse(dep + "Version", defaultVersions(dep))
+  ivy"$org::$dep:$version"
+}
+
+class FirrtlInterpreterModule(val crossScalaVersion: String) extends CommonModule {
+  override def artifactName = "firrtl-interpreter"
+
+  def chiselDeps = Agg("firrtl").map { d => getVersion(d) }
+
+  override def ivyDeps = Agg(
+    ivy"org.scala-lang.modules:scala-jline:2.12.1"
+  ) ++ chiselDeps
+
+  object test extends Tests {
+    override def ivyDeps = Agg(
+      ivy"org.scalatest::scalatest:3.0.1",
+      ivy"org.scalacheck::scalacheck:1.13.4"
+    )
+    def testFrameworks = Seq("org.scalatest.tools.Framework")
+  }
+
+}

--- a/build.sc
+++ b/build.sc
@@ -13,14 +13,14 @@ trait CrossUnRootedSbtModule extends CrossSbtModule {
 }
 
 trait CommonModule extends CrossUnRootedSbtModule with PublishModule {
-  def publishVersion = "1.2-SNAPSHOT"
+  def publishVersion = "1.1-SNAPSHOT"
 
   def pomSettings = PomSettings(
     description = artifactName(),
     organization = "edu.berkeley.cs",
-    url = "https://github.com/freechipsproject/firrtl-interpreter.git",
+    url = "https://github.com/ucb-bar/treadle.git",
     licenses = Seq(License.`BSD-3-Clause`),
-    versionControl = VersionControl.github("freechipsproject", "firrtl-interpreter"),
+    versionControl = VersionControl.github("ucb-bar", "treadle"),
     developers = Seq(
       Developer("chick",    "Charles Markley",      "https://aspire.eecs.berkeley.edu/author/chick/")
     )
@@ -42,29 +42,29 @@ trait CommonModule extends CrossUnRootedSbtModule with PublishModule {
 val crossVersions = Seq("2.11.12", "2.12.4")
 
 // Make this available to external tools.
-object firrtlInterpreter extends Cross[FirrtlInterpreterModule](crossVersions: _*) {
+object treadle extends Cross[TreadleModule](crossVersions: _*) {
   def defaultVersion(ev: Evaluator[Any]) = T.command{
     println(crossVersions.head)
   }
 
   def compile = T{
-    firrtlInterpreter(crossVersions.head).compile()
+    treadle(crossVersions.head).compile()
   }
 
   def jar = T{
-    firrtlInterpreter(crossVersions.head).jar()
+    treadle(crossVersions.head).jar()
   }
 
   def test = T{
-    firrtlInterpreter(crossVersions.head).test.test()
+    treadle(crossVersions.head).test.test()
   }
 
   def publishLocal = T{
-    firrtlInterpreter(crossVersions.head).publishLocal()
+    treadle(crossVersions.head).publishLocal()
   }
 
   def docJar = T{
-    firrtlInterpreter(crossVersions.head).docJar()
+    treadle(crossVersions.head).docJar()
   }
 }
 
@@ -76,13 +76,14 @@ def getVersion(dep: String, org: String = "edu.berkeley.cs") = {
   ivy"$org::$dep:$version"
 }
 
-class FirrtlInterpreterModule(val crossScalaVersion: String) extends CommonModule {
-  override def artifactName = "firrtl-interpreter"
+class TreadleModule(val crossScalaVersion: String) extends CommonModule {
+  override def artifactName = "treadle"
 
   def chiselDeps = Agg("firrtl").map { d => getVersion(d) }
 
   override def ivyDeps = Agg(
-    ivy"org.scala-lang.modules:scala-jline:2.12.1"
+    ivy"org.scala-lang.modules:scala-jline:2.12.1",
+    ivy"org.json4s::json4s-native:3.5.3"
   ) ++ chiselDeps
 
   object test extends Tests {


### PR DESCRIPTION
Inherit `mill` support from `firrtl-interpreter`. The (nop) commits prior to May 17, 2018 are a side-effect of inheriting the files from `firrtl-interpreter`.
