### PR TITLE
Fix assert() macro failure.

### DIFF
--- a/src/test/scala/treadle/TestUtilsSpec.scala
+++ b/src/test/scala/treadle/TestUtilsSpec.scala
@@ -33,7 +33,7 @@ class TestUtilsSpec extends FlatSpec with Matchers {
     var count = 0
     for (i <- IntWidthTestValuesGenerator(-18, -12)) {
       print(s"$i")
-      if (count > 18) assert(condition = false)
+      if (count > 18) assert(false)
       count += 1
     }
     println()
@@ -103,7 +103,7 @@ class TestUtilsSpec extends FlatSpec with Matchers {
     var count = 0
     for (i <- BigIntTestValuesGenerator(-18, -12)) {
 //      println(s"$i")
-      if (count > 18) assert(condition = false)
+      if (count > 18) assert(false)
       count += 1
 
     }


### PR DESCRIPTION
PR #41 introduced the following compile-time error:
```bash
[info] Compiling 59 Scala sources to .../treadle/target/scala-2.11/test-classes ...
[error] .../treadle/src/test/scala/treadle/TestUtilsSpec.scala:36:29: macro applications do not support named and/or default arguments
[error]       if (count > 18) assert(condition = false)
[error]                             ^
[error] .../treadle/src/test/scala/treadle/TestUtilsSpec.scala:106:29: macro applications do not support named and/or default arguments
[error]       if (count > 18) assert(condition = false)
[error]                             ^
[error] two errors found
[error] (Test / compileIncremental) Compilation failed
```