### PR TITLE
Circuits using withClock were failing

### DIFF
--- a/src/main/scala/treadle/TreadleTester.scala
+++ b/src/main/scala/treadle/TreadleTester.scala
@@ -3,6 +3,7 @@
 package treadle
 
 import java.io.PrintWriter
+import java.util.Calendar
 
 import treadle.chronometry.UTC
 import treadle.executable._
@@ -26,16 +27,18 @@ class TreadleTester(input: String, optionsManager: HasTreadleSuite = new Treadle
   treadle.random.setSeed(optionsManager.treadleOptions.randomSeed)
 
   val wallTime = UTC()
+
+  val engine         : ExecutionEngine  = ExecutionEngine(input, optionsManager, wallTime)
+  val treadleOptions : TreadleOptions   = optionsManager.treadleOptions
+
   wallTime.onTimeChange = () => {
     engine.vcdOption.foreach { vcd =>
       vcd.setTime(wallTime.currentTime)}
   }
 
-  val engine         : ExecutionEngine  = ExecutionEngine(input, optionsManager, wallTime)
-  val treadleOptions : TreadleOptions   = optionsManager.treadleOptions
-
   val resetName: String = treadleOptions.resetName
   def setVerbose(value: Boolean = true): Unit = {
+    wallTime.isVerbose = value
     engine.setVerbose(value)
   }
 
@@ -95,6 +98,12 @@ class TreadleTester(input: String, optionsManager: HasTreadleSuite = new Treadle
   }
 
   setVerbose(treadleOptions.setVerbose)
+
+  wallTime.setTime(0L)
+
+  if(engine.verbose) {
+    println(s"${"-"*60}\nStarting Treadle at ${Calendar.getInstance.getTime} WallTime: ${wallTime.currentTime}")
+  }
 
   if(treadleOptions.writeVCD) {
     optionsManager.setTopNameIfNotSet(engine.ast.main)
@@ -219,7 +228,7 @@ class TreadleTester(input: String, optionsManager: HasTreadleSuite = new Treadle
         println(s"peeking $name on stale circuit, refreshing START")
       }
       engine.evaluateCircuit()
-      wallTime.incrementTime(combinationalDelay)
+      clockStepper.combinationalBump(combinationalDelay)
       if(engine.verbose) {
         println(s"peeking $name on stale circuit, refreshing DONE")
       }

--- a/src/main/scala/treadle/chronometry/UTC.scala
+++ b/src/main/scala/treadle/chronometry/UTC.scala
@@ -2,15 +2,22 @@
 
 package treadle.chronometry
 
+import treadle.utils.Render
+
 import scala.collection.mutable
 
 class UTC(scaleName: String = "picoseconds") {
   private var internalTime: Long = 0L
   def currentTime:  Long = internalTime
   def setTime(time: Long): Unit = {
-    internalTime = time
-    onTimeChange()
+    if(internalTime < time || time == 0L) {
+      internalTime = time
+      if (isVerbose) Render.headerBar(s"WallTime: $internalTime")
+      onTimeChange()
+    }
   }
+
+  var isVerbose: Boolean = false
 
   val eventQueue = new mutable.PriorityQueue[Task]()
 

--- a/src/main/scala/treadle/executable/ClockInfo.scala
+++ b/src/main/scala/treadle/executable/ClockInfo.scala
@@ -13,7 +13,7 @@ package treadle.executable
   *
   * @param name           the signal name of a clock
   * @param period         how many ticks between rising edges of this clock
-  * @param initialOffset  how many ticks before the first rising edge occurs, this value can be negative
+  * @param initialOffset  the tick where the first up transition takes place.
   */
 case class ClockInfo(
   name          : String = ClockInfo.DefaultName,
@@ -22,6 +22,9 @@ case class ClockInfo(
 ) {
   val upPeriod   : Long = period / 2
   val downPeriod : Long = period - upPeriod
+  if(initialOffset <= 0) {
+    throw TreadleException(s"initialOffset in ClockInfo for $name must be positive. Found value $initialOffset")
+  }
 }
 
 /**

--- a/src/main/scala/treadle/executable/DataStore.scala
+++ b/src/main/scala/treadle/executable/DataStore.scala
@@ -7,6 +7,7 @@ import org.json4s._
 import org.json4s.native.JsonMethods._
 import org.json4s.JsonDSL._
 import treadle.ScalaBlackBox
+import treadle.utils.Render
 
 import scala.collection.mutable
 
@@ -178,30 +179,37 @@ extends HasDataArrays {
     val index: Int = symbol.index
 
     var value: Int = 0
+    var lastValue: Int = 0
 
     def runLean(): Unit = {
+      lastValue = intData(index)
       intData(index) = value
-      if(value == triggerOnValue) {
+      if(value == triggerOnValue && lastValue != triggerOnValue) {
         scheduler.executeTriggeredAssigns(symbol)
       }
-      else {
+      else if(value != triggerOnValue && lastValue == triggerOnValue) {
         scheduler.executeTriggeredUnassigns(symbol)
       }
     }
 
     def runFull(): Unit = {
+      lastValue = intData(index)
       intData(index) = value
-      if(value == triggerOnValue) {
-        if(isVerbose) println(s"===> Starting triggered assigns for $symbol")
-        scheduler.executeTriggeredAssigns(symbol)
-        if(isVerbose) println(s"===> Finished triggered assigns for $symbol")
-      }
-      else {
-        if(isVerbose) println(s"===> Starting triggered assigns for $symbol")
-        scheduler.executeTriggeredUnassigns(symbol)
-        if(isVerbose) println(s"===> Finished triggered assigns for $symbol")
-      }
+
       runPlugins(symbol)
+
+      if(value == triggerOnValue && lastValue != triggerOnValue) {
+        if(isVerbose) Render.headerBar(s"triggered assigns for ${symbol.name}", offset = 8)
+        scheduler.executeTriggeredAssigns(symbol)
+        if(isVerbose) Render.headerBar(s"done triggered assigns for ${symbol.name}", offset = 8)
+      }
+      else if(value != triggerOnValue && lastValue == triggerOnValue) {
+        if(scheduler.triggeredUnassigns.contains(symbol)) {
+          if(isVerbose) Render.headerBar(s"triggered un-assigns for ${symbol.name}", offset = 8)
+          scheduler.executeTriggeredUnassigns(symbol)
+          if(isVerbose) Render.headerBar(s"done triggered un-assigns for ${symbol.name}", offset = 8)
+        }
+      }
     }
 
     override def setLeanMode(isLean: Boolean): Unit = {
@@ -220,31 +228,39 @@ extends HasDataArrays {
 
     val index: Int = symbol.index
 
+    var lastValue: Int = 0
+
     def runLean(): Unit = {
       val value = expression()
       intData(index) = value
-      if(value == triggerOnValue) {
+      lastValue = intData(index)
+      if(value == triggerOnValue && lastValue != triggerOnValue) {
         scheduler.executeTriggeredAssigns(symbol)
       }
-      else {
+      else if(value != triggerOnValue && lastValue == triggerOnValue) {
         scheduler.executeTriggeredUnassigns(symbol)
       }
     }
 
     def runFull(): Unit = {
       val value = expression()
+      lastValue = intData(index)
       intData(index) = value
-      if(value == triggerOnValue) {
-        if(isVerbose) println(s"===> Starting triggered assigns for $symbol")
-        scheduler.executeTriggeredAssigns(symbol)
-        if(isVerbose) println(s"===> Finished triggered assigns for $symbol")
-      }
-      else {
-        if(isVerbose) println(s"===> Starting triggered assigns for $symbol")
-        scheduler.executeTriggeredUnassigns(symbol)
-        if(isVerbose) println(s"===> Finished triggered assigns for $symbol")
-      }
+
       runPlugins(symbol)
+
+      if(value == triggerOnValue && lastValue != triggerOnValue) {
+        if(isVerbose) Render.headerBar(s"triggered assigns for ${symbol.name}", offset = 8)
+        scheduler.executeTriggeredAssigns(symbol)
+        if(isVerbose) Render.headerBar(s"done triggered assigns for ${symbol.name}", offset = 8)
+      }
+      else if(value != triggerOnValue && lastValue == triggerOnValue) {
+        if(scheduler.triggeredUnassigns.contains(symbol)) {
+          if(isVerbose) Render.headerBar(s"triggered un-assigns for ${symbol.name}", offset = 8)
+          scheduler.executeTriggeredUnassigns(symbol)
+          if(isVerbose) Render.headerBar(s"done triggered un-assigns for ${symbol.name}", offset = 8)
+        }
+      }
     }
 
     override def setLeanMode(isLean: Boolean): Unit = {

--- a/src/main/scala/treadle/executable/ExpressionCompiler.scala
+++ b/src/main/scala/treadle/executable/ExpressionCompiler.scala
@@ -85,21 +85,21 @@ class ExpressionCompiler(
   ): Unit = {
     val assigner = (symbol.dataSize, expressionResult) match {
       case (IntSize,  result: IntExpressionResult)  =>
-        if(scheduler.triggeredAssigns.contains(symbol)) {
+        if(scheduler.isTrigger(symbol)) {
           dataStore.TriggerExpressionAssigner(symbol, scheduler, result.apply, triggerOnValue = 1, info)
         }
         else {
           dataStore.AssignInt(symbol, result.apply, info)
         }
       case (IntSize,  result: LongExpressionResult) =>
-        if(scheduler.triggeredAssigns.contains(symbol)) {
+        if(scheduler.isTrigger(symbol)) {
           dataStore.TriggerExpressionAssigner(symbol, scheduler, ToInt(result.apply).apply, triggerOnValue = 1, info)
         }
         else {
           dataStore.AssignInt(symbol,  ToInt(result.apply).apply, info)
         }
       case (IntSize,  result: BigExpressionResult)  =>
-        if(scheduler.triggeredAssigns.contains(symbol)) {
+        if(scheduler.isTrigger(symbol)) {
           dataStore.TriggerExpressionAssigner(symbol, scheduler, ToInt(result.apply).apply, triggerOnValue = 1, info)
         }
         else {
@@ -822,6 +822,8 @@ class ExpressionCompiler(
       case x =>
         throw TreadleException(s"Top level module is not the right kind of module $x")
     }
+
+    scheduler.registerClocks ++= FindRegisterClocks.run(module, circuit, symbolTable)
 
     processModule("", module, circuit)
 

--- a/src/main/scala/treadle/executable/FindRegisterClocks.scala
+++ b/src/main/scala/treadle/executable/FindRegisterClocks.scala
@@ -1,0 +1,70 @@
+// See LICENSE for license details.
+
+package treadle.executable
+
+import firrtl.WRef
+import firrtl.ir._
+
+import scala.collection.mutable
+
+object FindRegisterClocks {
+  //scalastyle:off method.length cyclomatic.complexity
+  def run(topModule: DefModule, circuit: Circuit, symbolTable: SymbolTable): mutable.HashSet[Symbol] = {
+
+    val clockSymbols = new mutable.HashSet[Symbol]
+
+    def processModule(modulePrefix: String, myModule: DefModule, circuit: Circuit): Unit = {
+      def expand(name: String): String = if(modulePrefix.isEmpty) name else modulePrefix + "." + name
+
+      def processStatements(modulePrefix: String, circuit: Circuit, statement: firrtl.ir.Statement): Unit = {
+        def expand(name: String): String = if(modulePrefix.isEmpty) name else modulePrefix + "." + name
+
+        def getDrivingClock(clockExpression: Expression): Option[Symbol] = {
+
+          clockExpression match {
+            case WRef(clockName, _, _, _) =>
+              for {
+                clockSym <- symbolTable.get(expand(clockName))
+                topClock <- symbolTable.findHighestClock(clockSym)
+              } yield {
+                topClock
+              }
+            case _ =>
+              None
+          }
+        }
+
+        statement match {
+          case block: Block =>
+            var statementNumber = 0
+            while(statementNumber < block.stmts.length) {
+              processStatements(modulePrefix, circuit, block.stmts(statementNumber))
+              statementNumber += 1
+            }
+
+          case DefRegister(info, name, _, clockExpression, _, _) =>
+
+            getDrivingClock(clockExpression) match {
+              case Some(clockSymbol) =>
+                clockSymbols += clockSymbol
+
+              case _ =>
+            }
+
+          case _ =>
+        }
+      }
+
+      myModule match {
+        case module: firrtl.ir.Module =>
+          processStatements(modulePrefix, circuit: Circuit, module.body)
+        case _ =>
+      }
+    }
+
+    processModule(modulePrefix = "", topModule, circuit)
+
+    clockSymbols
+  }
+
+}

--- a/src/main/scala/treadle/executable/Scheduler.scala
+++ b/src/main/scala/treadle/executable/Scheduler.scala
@@ -30,6 +30,12 @@ class Scheduler(val symbolTable: SymbolTable) extends LazyLogging {
       }
     }
 
+  val registerClocks       : mutable.HashSet[Symbol] = new mutable.HashSet
+
+  def isTrigger(symbol: Symbol): Boolean = {
+    registerClocks.contains(symbol) || triggeredAssigns.contains(symbol)
+  }
+
   val triggeredUnassigns     : mutable.HashMap[Symbol,mutable.ArrayBuffer[Assigner]] =
     new mutable.HashMap[Symbol,mutable.ArrayBuffer[Assigner]] {
       override def default(key: Symbol): ArrayBuffer[Assigner] = {
@@ -214,7 +220,13 @@ class Scheduler(val symbolTable: SymbolTable) extends LazyLogging {
     combinationalAssigns.map(renderAssigner).mkString("\n") + "\n\n" +
     triggeredAssigns.map { case (symbol, assigners) =>
       s"Assigners triggered by ${symbol.name} (${assigners.length})\n" +
-      assigners.map(renderAssigner).mkString("\n")
+        assigners.map(renderAssigner).mkString("\n") +
+        "\n"
+    }.mkString("\n") +
+      triggeredUnassigns.map { case (symbol, assigners) =>
+      s"Un-assigners triggered by ${symbol.name} (${assigners.length})\n" +
+        assigners.map(renderAssigner).mkString("\n") +
+        "\n"
     }.mkString("\n") +
     "\n\n"
   }

--- a/src/main/scala/treadle/utils/Render.scala
+++ b/src/main/scala/treadle/utils/Render.scala
@@ -2,6 +2,7 @@
 
 package treadle.utils
 
+//scalastyle:off magic.number regex
 object Render {
   def binary(value: BigInt, bitWidth: Int): String = {
     val numberString = if(value < 0) {
@@ -18,5 +19,11 @@ object Render {
     else {
       numberString
     }
+  }
+
+  def headerBar(string: String, offset: Int = 4, width: Int = 80): Unit = {
+    val header = "-" * offset + " " + string + " " +
+      ("-" * (width - string.length - offset - 2))
+    println(header)
   }
 }

--- a/src/test/scala/treadle/CombinationalDelaySpec.scala
+++ b/src/test/scala/treadle/CombinationalDelaySpec.scala
@@ -30,7 +30,7 @@ class CombinationalDelaySpec extends FreeSpec with Matchers {
     val optionsManager = new TreadleOptionsManager {
       treadleOptions = treadleOptions.copy(
         writeVCD = false,
-        clockInfo = Seq(ClockInfo("clock", period = 1000L, initialOffset = 0)),
+        clockInfo = Seq(ClockInfo("clock", period = 1000L, initialOffset = 500L)),
         vcdShowUnderscored = false,
         setVerbose = false,
         showFirrtlAtLoad = false,

--- a/src/test/scala/treadle/PrintStopSpec.scala
+++ b/src/test/scala/treadle/PrintStopSpec.scala
@@ -89,6 +89,7 @@ class PrintStopSpec extends FlatSpec with Matchers {
       val tester = TreadleTester(input, manager)
 
       tester.step(2)
+      tester.finish
     }
     output.toString().contains("HELLO WORLD") should be (true)
     output.toString.split("\n").count(_.contains("HELLO WORLD")) should be (2)

--- a/src/test/scala/treadle/RiscVMiniSimpleSpec.scala
+++ b/src/test/scala/treadle/RiscVMiniSimpleSpec.scala
@@ -19,7 +19,7 @@ class RiscVMiniSimpleSpec extends FreeSpec with Matchers {
         setVerbose = false,
         showFirrtlAtLoad = false,
         rollbackBuffers = 0,
-        clockInfo = Seq(ClockInfo("clock", period = 10, -4)),
+        clockInfo = Seq(ClockInfo("clock", period = 10, initialOffset = 1)),
         symbolsToWatch = Seq()
       )
     }
@@ -27,7 +27,7 @@ class RiscVMiniSimpleSpec extends FreeSpec with Matchers {
     val tester = new TreadleTester(input, optionsManager)
 
     intercept[StopException] {
-      tester.step(300)
+      tester.step(400)
     }
     tester.report()
     tester.engine.writeVCD()

--- a/src/test/scala/treadle/blackboxes/BlackBoxWithState.scala
+++ b/src/test/scala/treadle/blackboxes/BlackBoxWithState.scala
@@ -47,7 +47,7 @@ class BlackBoxWithState extends FreeSpec with Matchers {
         symbolsToWatch = Seq("io_data"),
         blackBoxFactories = Seq(new AccumBlackBoxFactory),
         callResetAtStartUp = true,
-        clockInfo = Seq(ClockInfo("clock", 10, -2))
+        clockInfo = Seq(ClockInfo("clock", 10, 8))
       )
     }
     val tester = new TreadleTester(input, manager)
@@ -88,8 +88,8 @@ class AccumulatorBlackBox(val name: String) extends ScalaBlackBox {
       case PositiveEdge =>
         if(! isInReset) {
           ps = ns
-          ns = ps + 1
         }
+        ns = ps + 1
         // println(s"blackbox:$name ps $ps ns $ns")
       case _ =>
         // println(s"not positive edge, not action for cycle in $name")

--- a/src/test/scala/treadle/chronometry/ClockCrossingSpec.scala
+++ b/src/test/scala/treadle/chronometry/ClockCrossingSpec.scala
@@ -1,0 +1,77 @@
+// See LICENSE for license details.
+
+package treadle.chronometry
+
+import firrtl.{Driver, ExecutionOptionsManager}
+import firrtl.{FirrtlExecutionSuccess, HasFirrtlOptions, Parser}
+import firrtl.passes.CheckChirrtl
+import org.scalatest.{FreeSpec, Matchers}
+import treadle.executable.ClockInfo
+import treadle.{TreadleOptionsManager, TreadleTester}
+import treadle.utils.ToLoFirrtl
+
+//noinspection ScalaStyle
+class ClockCrossingSpec extends FreeSpec with Matchers {
+
+  "clocks generated using asClock should function properly by advancing their associated registers" in {
+    val chirrtlString =
+      """
+        |;buildInfoPackage: chisel3, version: 3.2-SNAPSHOT, scalaVersion: 2.11.12, sbtVersion: 1.1.1
+        |circuit ClockCrossing :
+        |  module ClockCrossing :
+        |    input clock : Clock
+        |    input reset : UInt<1>
+        |    output io : {flip divIn : UInt<8>, mainOut : UInt<8>}
+        |
+        |    reg divClock : UInt<1>, clock with : (reset => (reset, UInt<1>("h01"))) @[ClockCrossingTest.scala 22:29]
+        |
+        |    node _T_12 = eq(divClock, UInt<1>("h00")) @[ClockCrossingTest.scala 23:19]
+        |    divClock <= _T_12 @[ClockCrossingTest.scala 23:16]
+        |
+        |    wire divRegWire : UInt @[ClockCrossingTest.scala 25:28]
+        |    node _T_14 = asClock(divClock) @[ClockCrossingTest.scala 26:26]
+        |
+        |    reg _T_17 : UInt, _T_14 with : (reset => (reset, UInt<1>("h01"))) @[ClockCrossingTest.scala 27:29]
+        |
+        |    _T_17 <= io.divIn @[ClockCrossingTest.scala 27:29]
+        |    divRegWire <= _T_17 @[ClockCrossingTest.scala 28:20]
+        |
+        |    reg mainReg : UInt, clock with : (reset => (reset, UInt<1>("h00"))) @[ClockCrossingTest.scala 31:28]
+        |    mainReg <= divRegWire @[ClockCrossingTest.scala 31:28]
+        |
+        |    io.mainOut <= mainReg @[ClockCrossingTest.scala 32:18]
+        |
+      """.stripMargin
+
+    val firrtlOptionsManager = new ExecutionOptionsManager("test") with HasFirrtlOptions {
+      firrtlOptions = firrtlOptions.copy(firrtlSource = Some(chirrtlString), compilerName = "low")
+    }
+
+    Driver.execute(firrtlOptionsManager) match {
+      case FirrtlExecutionSuccess(_, highFirrtl) =>
+        val optionsManager = new TreadleOptionsManager {
+          commonOptions = commonOptions.copy(targetDirName = "test_run_dir/clock_crossing")
+          treadleOptions = treadleOptions.copy(
+            setVerbose = true, writeVCD = true, callResetAtStartUp = false,
+            showFirrtlAtLoad = false,
+            clockInfo = Seq(ClockInfo(name = "clock", period = 2, initialOffset = 1)))
+        }
+
+        val tester = new TreadleTester(highFirrtl, optionsManager)
+
+        tester.reset(8)
+
+        tester.poke("io_divIn", 0x42)
+        tester.expect("io_mainOut", 0)  // initial register value
+        tester.step()
+        tester.expect("io_mainOut", 1)  // initial value of divReg
+        tester.step()  // for divided clock to have a rising edge
+        tester.expect("io_mainOut", 1)  // one-cycle-delay divReg
+        tester.step()  // for main clock register to propagate
+        tester.expect("io_mainOut", 0x42)  // updated value propagates
+        tester.finish
+      case _ =>
+
+    }
+  }
+}


### PR DESCRIPTION
* Attempt to clean up verbose display to make diagnostics easier
* Render.headerBar is attempt to make easier to see blocks in verbose output
* ClockInfo must specify a initialOffset > 0, i.e it is not possible to start with clock set high
* Single step clock improvements
  * Has more logic to handle bootstrap clock
  * Keep track explicitly of combinational time bumps to better handle down clock
  * Reset handling improved (reset may be lowered at times other than clock transitions)
* withClock construct requires special pass to find all clocks that trigger registers
* Fix problem with BlackBoxWithState exposed by this refactor