### PR TITLE
Makes options and BlackBox support distinct from Interpreter

### DIFF
--- a/src/main/scala/treadle/Driver.scala
+++ b/src/main/scala/treadle/Driver.scala
@@ -41,45 +41,45 @@ trait HasTreadleOptions {
 
   var treadleOptions = TreadleOptions()
 
-  parser.note("firrtl-engine-options")
+  parser.note("treadle-options")
 
-  parser.opt[Unit]("fint-write-vcd")
-    .abbr("fiwv")
+  parser.opt[Unit]("tr-write-vcd")
+    .abbr("tiwv")
     .foreach { _ =>
       treadleOptions = treadleOptions.copy(writeVCD = true)
     }
     .text("writes vcd execution log, filename will be base on top")
 
-  parser.opt[Unit]("fint-vcd-show-underscored-vars")
-    .abbr("fivsuv")
+  parser.opt[Unit]("tr-vcd-show-underscored-vars")
+    .abbr("tivsuv")
     .foreach { _ =>
       treadleOptions = treadleOptions.copy(vcdShowUnderscored = true)
     }
     .text("vcd output by default does not show var that start with underscore, this overrides that")
 
-  parser.opt[Unit]("fint-verbose")
-    .abbr("fiv")
+  parser.opt[Unit]("tr-verbose")
+    .abbr("tv")
     .foreach {_ =>
       treadleOptions = treadleOptions.copy(setVerbose = true)
     }
     .text("makes engine very verbose")
 
-  parser.opt[Unit]("fint-ordered-exec")
-    .abbr("fioe")
+  parser.opt[Unit]("tr-ordered-exec")
+    .abbr("tioe")
     .foreach { _ =>
       treadleOptions = treadleOptions.copy(setOrderedExec = true)
     }
     .text("operates on dependencies optimally, can increase overhead, makes verbose mode easier to read")
 
   parser.opt[Unit]("fr-allow-cycles")
-    .abbr("fiac")
+    .abbr("tiac")
     .foreach { _ =>
       treadleOptions = treadleOptions.copy(allowCycles = true)
     }
     .text(s"allow combinational loops to be processed, though unreliable, default is ${treadleOptions.allowCycles}")
 
-  parser.opt[Long]("fint-random-seed")
-    .abbr("firs")
+  parser.opt[Long]("tr-random-seed")
+    .abbr("tirs")
       .valueName("<long-value>")
     .foreach { x =>
       treadleOptions = treadleOptions.copy(randomSeed = x)
@@ -87,35 +87,35 @@ trait HasTreadleOptions {
     .text("seed used for random numbers generated for tests and poison values, default is current time in ms")
 
   parser.opt[Unit]("show-firrtl-at-load")
-    .abbr("fisfas")
+    .abbr("tisfas")
     .foreach { _ =>
       treadleOptions = treadleOptions.copy(showFirrtlAtLoad = true)
     }
     .text("compiled low firrtl at firrtl load time")
 
   parser.opt[Unit]("dont-run-lower-compiler-on-load")
-    .abbr("filcol")
+    .abbr("tilcol")
     .foreach { _ =>
       treadleOptions = treadleOptions.copy(lowCompileAtLoad = false)
     }
     .text("run lowering compiler when firrtl file is loaded")
 
   parser.opt[Unit]("validif-random")
-    .abbr("fivir")
+    .abbr("tivir")
     .foreach { _ =>
       treadleOptions = treadleOptions.copy(validIfIsRandom = true)
     }
     .text("validIf returns random value when condition is false")
 
   parser.opt[Unit]("call-reset-at-start")
-    .abbr("ficras")
+    .abbr("ticras")
     .foreach { _ =>
       treadleOptions = treadleOptions.copy(callResetAtStartUp = true)
     }
     .text("has the tester automatically do a reset on it's own at startup")
 
-  parser.opt[Int]("fint-rollback-buffers")
-    .abbr("firb")
+  parser.opt[Int]("tr-rollback-buffers")
+    .abbr("tirb")
     .valueName("<int-value>")
     .foreach { x =>
       treadleOptions = treadleOptions.copy(rollbackBuffers = x)
@@ -134,8 +134,8 @@ trait HasTreadleOptions {
         throw TreadleException(s"Bad clock info string $input, should be name[:period[:offset]]")
     }
   }
-  parser.opt[String]("fint-clock-info")
-    .abbr("fici")
+  parser.opt[String]("tr-clock-info")
+    .abbr("tici")
     .unbounded()
     .valueName("<string>")
     .foreach { x =>
@@ -143,16 +143,16 @@ trait HasTreadleOptions {
     }
     .text("clock-name[:period[:initial-offset]]")
 
-  parser.opt[Seq[String]]("fint-symbols-to-watch")
-    .abbr("fistw")
+  parser.opt[Seq[String]]("tr-symbols-to-watch")
+    .abbr("tstw")
     .valueName("symbols]")
     .foreach { x =>
     treadleOptions = treadleOptions.copy(symbolsToWatch = x)
     }
     .text("symbol[,symbol[...]")
 
-  parser.opt[String]("fint-reset-name")
-    .abbr("firn")
+  parser.opt[String]("tr-reset-name")
+    .abbr("tirn")
     .valueName("<string>")
     .foreach { x =>
       treadleOptions = treadleOptions.copy(resetName = x)

--- a/src/main/scala/treadle/ScalaBlackBox.scala
+++ b/src/main/scala/treadle/ScalaBlackBox.scala
@@ -14,7 +14,7 @@ import scala.collection._
   */
 trait ScalaBlackBox {
   def name: String
-  def fullName(componentName: String): String = s"$name.$componentName"
+  def completeName(componentName: String): String = s"$name.$componentName"
 
   /**
     * getOutput is called to determine the value for the named output at the
@@ -29,8 +29,10 @@ trait ScalaBlackBox {
 
   /**
     * Called whenever the cycle command of the engine is called.
+    * @param transition, tells whether clock went up or down or didn't change.
+    * @param clockName name of the clock, only need if there are multiple clocks
     */
-  def cycle(transition: Transition): Unit = {}
+  def clockChange(transition: Transition, clockName: String = ""): Unit = {}
 
   /**
     * returns a list of names of inputs that this output depends on.

--- a/src/main/scala/treadle/executable/BlackBoxCycler.scala
+++ b/src/main/scala/treadle/executable/BlackBoxCycler.scala
@@ -15,7 +15,7 @@ case class BlackBoxCycler(
 extends Assigner {
 
   override def run: FuncUnit = {
-    blackBox.cycle(PositiveEdge)
+    blackBox.clockChange(PositiveEdge, clockSymbol.name)
     if (isVerbose) {
       println(s"${symbol.name} : black box cycle($PositiveEdge)")
     }

--- a/src/test/scala/treadle/DriverSpec.scala
+++ b/src/test/scala/treadle/DriverSpec.scala
@@ -16,7 +16,7 @@ class DriverSpec extends FreeSpec with Matchers {
           |    y <= x
         """.stripMargin
       //      val engine = Driver.execute(Array.empty[String], input)
-      val engine = Driver.execute(Array("--fint-verbose"), input)
+      val engine = Driver.execute(Array("--tr-verbose"), input)
 
       engine should not be empty
 

--- a/src/test/scala/treadle/RegisterCycleTest.scala
+++ b/src/test/scala/treadle/RegisterCycleTest.scala
@@ -88,7 +88,7 @@ class RegisterCycleTest extends FreeSpec with Matchers {
       val output = new ByteArrayOutputStream()
       Console.withOut(new PrintStream(output)) {
         val optionsManager = new TreadleOptionsManager
-        optionsManager.parser.parse(Array("-fistw", "io_Out,mySubModule_1.io_Out"))
+        optionsManager.parser.parse(Array("-tstw", "io_Out,mySubModule_1.io_Out"))
 
         val tester = new TreadleTester(input, optionsManager)
         tester.poke("io_In", 1)

--- a/src/test/scala/treadle/blackboxes/BlackBoxOutputSpec.scala
+++ b/src/test/scala/treadle/blackboxes/BlackBoxOutputSpec.scala
@@ -25,7 +25,7 @@ class FanOutAdder extends ScalaBlackBox {
     inputValues.head + BigInt(inc)
   }
 
-  override def cycle(transition: Transition): Unit = {}
+  override def clockChange(transition: Transition, clockName: String): Unit = {}
 
   override def outputDependencies(outputName: String): Seq[String] = {
     outputName match {
@@ -59,7 +59,7 @@ class BlackBoxCounter extends ScalaBlackBox {
     counter
   }
 
-  override def cycle(transition: Transition): Unit = {
+  override def clockChange(transition: Transition, clockName: String): Unit = {
     if(transition == PositiveEdge) {
       if(! clearSet) counter += 1
     }

--- a/src/test/scala/treadle/blackboxes/BlackBoxWithState.scala
+++ b/src/test/scala/treadle/blackboxes/BlackBoxWithState.scala
@@ -10,8 +10,8 @@ import treadle.executable._
 
 // scalastyle:off magic.number
 /**
-  * This test is pretty sensitive to when the reset comes down.
-  * Hence the negative initialOffset
+  * Demonstrates how a black box can maintain and change internal state
+  * based on clock transitions
   */
 class BlackBoxWithState extends FreeSpec with Matchers {
   "BlackBoxWithState should pass a basic test" in {
@@ -83,7 +83,7 @@ class AccumulatorBlackBox(val name: String) extends ScalaBlackBox {
     }
   }
 
-  override def cycle(transition: Transition): Unit = {
+  override def clockChange(transition: Transition, clockName: String): Unit = {
     transition match {
       case PositiveEdge =>
         if(! isInReset) {
@@ -92,7 +92,7 @@ class AccumulatorBlackBox(val name: String) extends ScalaBlackBox {
         ns = ps + 1
         // println(s"blackbox:$name ps $ps ns $ns")
       case _ =>
-        // println(s"not positive edge, not action for cycle in $name")
+        // println(s"not positive edge, no action for cycle in $name")
     }
   }
 


### PR DESCRIPTION
Prior to this a project could not depend on both

For options
- all options preceded by "treadle-"
- all abbreviated options preceded by "t"

For black boxes
- cycle => clockChange
- fullName => completeName

Fixed up problem in Memory.scala where memory pipeline registers did not
have associated clocks defined, which could cause exception in verbose
mode.